### PR TITLE
Update + add tslint rules for React

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -11,9 +11,15 @@
       true,
       "ban-keywords",
       "check-format",
-      "allow-leading-underscore"
+      "allow-leading-underscore",
+      "allow-pascal-case"
     ],
     "interface-name": [true, "never-prefix"],
+    "interface-over-type-literal": false,
+    "jsx-boolean-value": [true, "never"],
+    "jsx-no-multiline-js": false,
+    "member-ordering": [false, {}],
+    "ordered-imports": false,
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
* `"allow-pascal-case"`: so that we can name react components this way
* `"interface-over-type-literal": false`: TS suggests that interfaces
have wider usage than types, but per internal conversation we're turning
off so that we can discover the differences ourselves.
* `"jsx-boolean-value": [true` "never"]`: when passing a boolean prop,
just pass or don't pass the prop; do not set the value to `true` or
`false`.
* `"jsx-no-multiline-js": false`: allow for loops (like `map`) in the
rendered DOM.
* `"member-ordering": [false {}]`: removes requirement to order `public`
methods before `private` and `protected` methods. Conventionally we are
placing `render`, which is a public function, at the end of the file.
* `"ordered-imports": false`: because TS is requiring us to import so
many packages using `import * as myImport from`, it seems easier to parse if
we can order those imports by the "as" (in this case, `myImport`).