### PR TITLE
Turn off typescript enforced member ordering

### DIFF
--- a/src/commands/tslint/index.ts
+++ b/src/commands/tslint/index.ts
@@ -22,6 +22,15 @@ const CONFIG = `{
     "ordered-imports": false,
     "quotemark": [true, "single", "jsx-double"],
     "semicolon": ["true", "never"],
+    "member-ordering": [
+      true,
+      {
+        "order": [
+          "public-constructor",
+          "public-instance-field"
+        ]
+      }
+    ],
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
* This allows us to put the render method below private methods.
* This allows us to put constructors above public instance fields.

https://palantir.github.io/tslint/rules/member-ordering/