### PR TITLE
Turn off typescript enforced object literal quotes

### DIFF
--- a/src/commands/tslint/index.ts
+++ b/src/commands/tslint/index.ts
@@ -23,6 +23,7 @@ const CONFIG = `{
       "allow-leading-underscore"
     ],
     "interface-name": [true, "never-prefix"],
+    "object-literal-key-quotes": false,
     "trailing-comma": [
       true,
       {


### PR DESCRIPTION
The rule conflicted with a rule that’s in prettier.

TypeScript’s `object-literal-key-quotes` rule was requiring object’s key’s whose values were strings, also be strings.

It was saying:

```
{ Accept: ‘application/json’ }
```

Needed to be:

```
{ ‘Accept’: ‘application/json’ }
```

Running prettier was removing the key quotes.

We’re going to stick with prettier’s rule, which removes key quotes unless they’re necessary. Eg `{ ‘Content-Type’: ‘application/json’ }`