### PR TITLE
Bump to version 0.0.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gnar-cli",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Add Gnar approved configurations to your apps in a jiffy",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
I am not entirely sure what happened - I suspect my local version of the gem was a few pulls behind? - but the published version of the gem does not reflect the current state of master. 

This is my bad! I blanked. This should be something we automate in the future., 