### PR TITLE
Fix Rails Passthrough Options, clean up Rails Framework 

### DIFF
--- a/src/frameworks/rails/index.ts
+++ b/src/frameworks/rails/index.ts
@@ -1,4 +1,3 @@
-import { Command } from 'commander'
 import { execCommand } from '../../utils/exec-command'
 import { Gnarrc } from '../../utils/gnarrc'
 import { stdOut } from '../../utils/std-out'
@@ -6,45 +5,13 @@ import { stdOut } from '../../utils/std-out'
 export class Rails {
   static command = 'rails'
 
-  static async init(name: string, extraArgs: string) {
+  static async init(name: string, extraArgs: Array<string>) {
     stdOut(`Setting up Rails New with Gnarly opinions...\n`)
 
     const rawOptions = await Gnarrc.get('rails/7/.railsrc')
+    const args = `${rawOptions.replace(/\r\n|\r|\n/g, ' ').trim()} ${extraArgs.join(' ')}`
 
-    const railsCommand = [
-      `rails new`,
-      `${name}`,
-      `${rawOptions.replace(/\r\n|\r|\n/g, ' ')}`.trim(),
-      `${extraArgs}`,
-      `\n`,
-    ].join(' ')
-
-    stdOut(`Running ${railsCommand}`)
-    execCommand(railsCommand)
-  }
-
-  static async run(
-    mainCommand: string,
-    subCommand: string,
-    _options: Record<string, unknown>,
-    command: Command,
-  ) {
-    const extraArgs = command.args
-      .filter(arg => arg !== mainCommand && arg !== subCommand)
-      .join(' ')
-
-    stdOut(`Setting up Rails New with Gnarly opinions...\n`)
-
-    const rawOptions = await Gnarrc.get('rails/7/.railsrc')
-
-    const railsCommand = [
-      `rails`,
-      `${mainCommand}`,
-      `${subCommand}`,
-      `${rawOptions.replace(/\r\n|\r|\n/g, ' ')}`.trim(),
-      `${extraArgs}`,
-      `\n`,
-    ].join(' ')
+    const railsCommand = [`rails new`, `${name}`, `${args}`, `\n`].join(' ')
 
     stdOut(`Running ${railsCommand}`)
     execCommand(railsCommand)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 import { program } from 'commander'
 
 import { stdOut } from './utils/std-out'
+import { getExtraArgs } from './utils/get-extra-args'
 
 import { Prettier } from './packages/prettier'
 import { Eslint } from './packages/eslint'
@@ -38,11 +39,9 @@ program
   .argument('<subCommand>', 'subcommand')
   .description('Greenfield Frameworks with Gnarly Opinions')
   .action((frameworkName, subCommand, _options, command) => {
-    const extraArgs = command.args.filter((arg: string) => arg !== subCommand).join(' ')
-
     switch (frameworkName.toLowerCase()) {
       case 'rails':
-        Rails.init(subCommand, extraArgs)
+        Rails.init(subCommand, getExtraArgs(command))
         break
       default:
         stdOut(`

--- a/src/utils/get-extra-args/index.ts
+++ b/src/utils/get-extra-args/index.ts
@@ -1,0 +1,5 @@
+import { Command } from 'commander'
+
+export function getExtraArgs({ args, processedArgs }: Command): Array<string> {
+  return args.filter((arg: string) => !processedArgs.includes(arg))
+}


### PR DESCRIPTION
This PR fixes a bug I noticed in my testing today, where options were not getting properly passed through to the `rails new` option. This is of limited utility (the template makes several assumptions and may produce weird code if you, say, want to use `sql` over `postgresql`) but is still a nifty feature. 

I noticed an opportunity for extraction and some dead code lying around, so I took the time to clean it up. Now, passthrough args work as intended! 