### PR TITLE
Use `prod-cli` branch of `.gnarrc`, allow for local DEV_URL option 

### DIFF
--- a/src/utils/gnarrc/index.ts
+++ b/src/utils/gnarrc/index.ts
@@ -2,15 +2,12 @@ import { writeFileSync } from 'node:fs'
 import axios from 'axios'
 import { stdOut } from '../std-out'
 
-const API = axios.create({
-  baseURL: 'https://raw.githubusercontent.com/TheGnarCo/.gnarrc/main/',
-})
+const baseURL =
+  process.env?.DEV_URL || 'https://raw.githubusercontent.com/TheGnarCo/.gnarrc/prod-cli/'
+
+const API = axios.create({ baseURL })
 
 export class Gnarrc {
-  static API = axios.create({
-    baseURL: 'https://raw.githubusercontent.com/TheGnarCo/.gnarrc/main/',
-  })
-
   static async getFile(path: string) {
     const filename = path.split('/').pop() || 'Error'
     stdOut(`Writing the following config to ${filename}\n\n`)


### PR DESCRIPTION
This Pr: 
 - switches to  use the `prod-cli` branch of gnarrc, rather than main 
 - allows for the inclusion of a `DEV_URL` node env, which can be used to swap out the source we draw files from (helpful when testing out changes to `.gnarrc`!) 

See [This PR](https://github.com/TheGnarCo/.gnarrc/pull/9) for more context 